### PR TITLE
chore(pkg): update @appsignal/express and @appsignal/nodejs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,11 @@
       }
     },
     "@appsignal/express": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@appsignal/express/-/express-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-ELhHxgWPxSDAbUQ6t32oVTQvCT8P2hGx4X6WETSRSDOSoekxHXktj+rB3Go7lxaTV9Mb6FTdN3j/8JQ7R3eZWg==",
+      "version": "0.1.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@appsignal/express/-/express-0.1.0-alpha.4.tgz",
+      "integrity": "sha512-FeYLfn56cMIZc8V+qZDuSyUrnQsgLvr5XiMZ7Y/ElRj/LN8gf+vqZkYMaRRT15FE5RZpioWvGY7AO0nFt44UQA==",
       "requires": {
-        "@appsignal/nodejs": "^0.1.0-alpha.7",
+        "@appsignal/nodejs": "^0.1.0-alpha.8",
         "tslib": "^1.10.0"
       }
     },
@@ -31,9 +31,9 @@
       }
     },
     "@appsignal/nodejs": {
-      "version": "0.1.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@appsignal/nodejs/-/nodejs-0.1.0-alpha.7.tgz",
-      "integrity": "sha512-oI+4VPWyzK1nJLHhipcZDBVr43i97MPsALNJtQedY1wYDVafMjJ6IPHGPjMT3QzgPn7cadcHJMXto3BtuIKh1w==",
+      "version": "0.1.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@appsignal/nodejs/-/nodejs-0.1.0-alpha.8.tgz",
+      "integrity": "sha512-nJzlohEYQTsGbM+61Ez9cJ9uIdhdQsqvqi1hl4CvZ6SQhPcgx3eB2OsQOnVj9elzK1cKLie0uMxTxht/sEr/QA==",
       "requires": {
         "node-addon-api": "^2.0.0",
         "node-gyp": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@appsignal/express": "0.1.0-alpha.3",
+    "@appsignal/express": "0.1.0-alpha.4",
     "@appsignal/javascript": "^1.1.1",
-    "@appsignal/nodejs": "0.1.0-alpha.7",
+    "@appsignal/nodejs": "0.1.0-alpha.8",
     "@appsignal/plugin-breadcrumbs-console": "^1.0.2",
     "@appsignal/plugin-breadcrumbs-network": "^1.0.0",
     "@appsignal/plugin-path-decorator": "^1.0.0",


### PR DESCRIPTION
My PR upstream was just merged. This update makes it so you don't need `yarn` installed on your system to install this package.